### PR TITLE
Sdcard enhancments

### DIFF
--- a/src/record/disk.c
+++ b/src/record/disk.c
@@ -390,6 +390,8 @@ void sdcard_check(SdcardContext_t* sdstat, uint32_t tkNow)
     bool mbFileSystem = false;
     const int MAX_REPAIR_TRIES = 3;
     int repairTries = 0;
+    
+    mbInserted = disk_insterted();
 
     if (mbInserted) {
         mbMounted = disk_mounted(sdstat->path, &mbTotal, &mbAvail);


### PR DESCRIPTION
## Disk Check and Repair Process

The process of checking and repairing a disk involves two main steps:

1. Executing the `disk_checkAndRepair()` function.
2. Implementing a `while` loop to retry the `disk_checkAndRepair()` function if the initial execution fails.

### 1. disk_checkAndRepair()

This function attempts to repair any potential issues with the filesystem on an SD card. It utilizes the `fsck` tool, which is a standard utility on Linux systems for checking the consistency of a file system and fixing any detected errors.

The function works as follows:

- It creates a child process using `fork()`.
- Within the child process, it opens a log file where it will record the output of the `fsck` tool.
- It redirects the child process's `stdout` and `stderr` to the log file.
- It checks if the `fsck` tool exists and is executable.
- If `fsck` is found, the child process is replaced with the `fsck` process using `execv()`.
- If `fsck` exits at all, it is an error and the child process exits with a failure status.

In the parent process:

- It waits for the child process to finish.
- It checks the exit status of the child process. 
- If the child process exited normally and `fsck` returned a successful exit code, it returns `true`.
- If the child process did not exit normally or `fsck` returned an error status, it returns `false`.

### 2. Retrying disk_checkAndRepair()

We implement a `while` loop that calls `disk_checkAndRepair()` with a maximum of three tries. 

```c
int attempts = 0;
while (!disk_checkAndRepair() && attempts < 3) {
    attempts++;
}
```
In each iteration, `disk_checkAndRepair()` is called. If it returns `false` (indicating that an error occurred), the loop continues until it either succeeds or reaches three attempts. If it succeeds, the loop breaks early.

This approach provides a level of fault tolerance. If a temporary error prevents successful repair on the first try, subsequent attempts may succeed.

### Logging Strategy

Given the critical nature of the `disk_checkAndRepair()` function, we've decided to create a separate log file for this function's actions and outcomes. This provides a detailed record that can prove invaluable for diagnostic and troubleshooting purposes, especially when dealing with hard-to-reproduce issues related to file system integrity and repair.

Furthermore, since our application typically logs to the SD card, there is a risk that standard application logs may not be written if the SD card is experiencing issues. By writing the logs for this function to a different location (i.e., the system's temporary directory), we ensure that they are preserved even when the SD card is not functioning properly.

Please note that while this logging strategy should work reliably in most typical cases, there may be rare scenarios where it might still encounter difficulties. For instance, if the entire file system is read-only due to an error, writing logs to any directory may fail. However, despite this potential limitation, we believe this strategy provides a significant improvement to our ability to monitor and debug the file system checking and repair process.
